### PR TITLE
fix: prepare for eslint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build/bin
 node_modules
 frontend/dist
 .idea
+.vscode

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
     "build": "vue-tsc --noEmit && vite build",
     "preview": "vite preview",
     "test": "vitest",
+    "lint": "eslint --ext .js,.jsx,.ts,.tsx,.vue src",
     "coverage": "vitest run --coverage"
   },
   "dependencies": {

--- a/frontend/src/components/SettingsModal.vue
+++ b/frontend/src/components/SettingsModal.vue
@@ -2,7 +2,7 @@
 import { PropType } from 'vue'
 import { TransitionChild, TransitionRoot, Dialog, DialogPanel } from '@headlessui/vue'
 import SettingsComponent from './Settings.vue'
-import Settings from '../lib/Settings' /*eslint-disable-line*/
+import Settings from '../lib/Settings' /* eslint-disable-line */
 
 const props = defineProps({
   show: {

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -6,7 +6,6 @@
     "moduleResolution": "Node",
     "strict": true,
     "jsx": "preserve",
-    "tsx": "preserve",
     "sourceMap": true,
     "resolveJsonModule": true,
     "isolatedModules": true,


### PR DESCRIPTION
Run `npm run lint` when ready. May want to reconcile tab/space rule first.