### PR TITLE
feat: extend attack api endpoints

### DIFF
--- a/cmd/reaper/main.go
+++ b/cmd/reaper/main.go
@@ -96,8 +96,9 @@ func main() {
 	api.Get("/endpoints", h.GetEndpoints)
 	api.Get("/endpoints/:id", h.GetEndpoint)
 	api.Post("/attack", h.CreateAttack)
-	// api.Get("/attacks", h.GetAttacks)
-	// api.Get("/attacks/:id", h.GetAttack)
+	api.Get("/attacks", h.GetAttacks)
+	api.Get("/attacks/:id", h.GetAttack)
+	api.Get("/attacks/:id/results", h.GetAttackResults)
 	api.Delete("/attack/:id/results", h.DeleteAttackResults)
 	// fuzz
 	// automate

--- a/internal/database/config.go
+++ b/internal/database/config.go
@@ -50,6 +50,7 @@ func Migrate() {
 		&models.Endpoint{},
 		&models.Request{},
 		&models.Response{},
+		&models.FuzzAttack{},
 		&models.FuzzResult{},
 		&models.Report{},
 		&models.AgentSession{},

--- a/internal/database/models/model.go
+++ b/internal/database/models/model.go
@@ -108,49 +108,30 @@ type Response struct {
 
 // TODO: clean up this mess
 type FuzzAttack struct {
-	ID        uint               `json:"id" gorm:"primaryKey"`
-	Type      string             `json:"type"` // header, body, param
-	Headers   []FuzzAttackHeader `json:"headers"`
-	Keys      []FuzzAttackKey    `json:"keys"`
-	Params    []FuzzAttackParam  `json:"params"`
-	CreatedAt time.Time          `json:"created_at"`
-	UpdatedAt time.Time          `json:"updated_at"`
-}
-
-type FuzzAttackHeader struct {
-	ID           uint      `json:"id" gorm:"primaryKey"`
-	FuzzAttackID uint      `json:"fuzz_attack_id" gorm:"foreignKey:ID"`
-	CreatedAt    time.Time `json:"created_at"`
-	UpdatedAt    time.Time `json:"updated_at"`
-}
-
-type FuzzAttackKey struct {
-	ID           uint      `json:"id" gorm:"primaryKey"`
-	FuzzAttackID uint      `json:"fuzz_attack_id" gorm:"foreignKey:ID"`
-	CreatedAt    time.Time `json:"created_at"`
-	UpdatedAt    time.Time `json:"updated_at"`
-}
-
-type FuzzAttackParam struct {
-	ID           uint      `json:"id" gorm:"primaryKey"`
-	FuzzAttackID uint      `json:"fuzz_attack_id" gorm:"foreignKey:ID"`
-	CreatedAt    time.Time `json:"created_at"`
-	UpdatedAt    time.Time `json:"updated_at"`
+	ID        uint      `json:"id" gorm:"primaryKey"`
+	Type      string    `json:"type"` // header, body, param
+	Headers   string    `json:"headers"`
+	Keys      string    `json:"keys"`
+	Params    string    `json:"params"`
+	Status    string    `json:"status"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
 }
 
 type FuzzResult struct {
-	ID uint `json:"id" gorm:"primaryKey"`
-	// FuzzAttackID uint      `json:"fuzz_attack_id" gorm:"foreignKey:ID"`
-	Hostname  string    `json:"hostname"`
-	IpAddress string    `json:"ip_address"`
-	Port      string    `json:"port"`
-	Scheme    string    `json:"scheme"`
-	URL       string    `json:"url"`
-	Endpoint  string    `json:"endpoint"`
-	Request   string    `json:"request"`
-	Response  string    `json:"response"`
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
+	ID           uint      `json:"id" gorm:"primaryKey"`
+	FuzzAttackID uint      `json:"fuzz_attack_id" gorm:"foreignKey:ID"`
+	Hostname     string    `json:"hostname"`
+	IpAddress    string    `json:"ip_address"`
+	Port         string    `json:"port"`
+	Scheme       string    `json:"scheme"`
+	URL          string    `json:"url"`
+	Endpoint     string    `json:"endpoint"`
+	Request      string    `json:"request"`
+	Response     string    `json:"response"`
+	StatusCode   int       `json:"status_code"`
+	CreatedAt    time.Time `json:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at"`
 }
 
 type Report struct {

--- a/internal/tools/agent/agent.go
+++ b/internal/tools/agent/agent.go
@@ -303,7 +303,8 @@ func (manager *AgentManager) runAgent() {
 
 		// Run the BOLA attack
 		manager.sendAgentMessage("Running the attack...")
-		err := fuzz.CreateAttack(function_model.Domain, excludedKeys, manager.Pool, manager.DB, 0, 0, 0)
+		// TODO: get the attack id
+		err := fuzz.CreateAttack(0, function_model.Domain, excludedKeys, manager.Pool, manager.DB, 0, 0, 0)
 		if err != nil {
 			slog.Error("Failed to create fuzz attack", "error", err)
 		}

--- a/ui/tailwind.config.js
+++ b/ui/tailwind.config.js
@@ -1,7 +1,7 @@
-const animate = require("tailwindcss-animate")
+import animate from "tailwindcss-animate";
 
 /** @type {import('tailwindcss').Config} */
-module.exports = {
+export default {
   darkMode: ["class"],
   safelist: ["dark"],
   prefix: "",


### PR DESCRIPTION
### 📑 Description (what does this PR add, change, remove)
- extends Attack API endpoints to enable AI agents to interact with the API better

Note: local database will need to be deleted, as this PR changes the schema

Adds:
```
api.Get("/attacks", h.GetAttacks)
api.Get("/attacks/:id", h.GetAttack)
api.Get("/attacks/:id/results", h.GetAttackResults)
```