### PR TITLE
chore: pin GitHub Actions to immutable SHA hashes

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,27 +17,27 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392  # v3.6.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2  # v3.10.0
       - name: Log in to the Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567  # v3.3.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804  # v5.7.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=ref,event=tag,pattern={{version}}
             type=semver,pattern={{version}}
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4  # v6.15.0
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/lint.go.yml
+++ b/.github/workflows/lint.go.yml
@@ -9,8 +9,8 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34  # v5.3.0
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34  # v5.3.0
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@90a3faa9d0182683851fbfa97ca1a2cb983bfca3  # v6.2.1
         with:
           distribution: goreleaser
           version: latest

--- a/.github/workflows/test.go.yml
+++ b/.github/workflows/test.go.yml
@@ -10,8 +10,8 @@ jobs:
         os: [ ubuntu-latest, macos-latest ]
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34  # v5.3.0
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -8,9 +8,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a  # v4.2.0
         with:
           node-version: lts/*
 


### PR DESCRIPTION
### 📑 Description (what does this PR add, change, remove)
This PR updates all GitHub Actions to use pinned hash references instead of just version tags for improved security and stability. This follows the GitHub security best practice of using hash-pinned references to prevent potential supply chain attacks.

The following actions were updated:
- actions/checkout from v4 to v4.2.2 (11bd71901bbe5b1630ceea73d27597364c9af683)
- actions/setup-go from v5 to v5.3.0 (f111f3307d8850f501ac008e886eec1fd1932a34)
- docker/setup-qemu-action from v3 to v3.6.0 (29109295f81e9208d7d86ff1c6c12d2833863392)
- docker/setup-buildx-action from v3 to v3.10.0 (b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2)
- docker/login-action from v3 to v3.3.0 (9780b0c442fbb1117ed29e0efdff1e18412f7567)
- docker/metadata-action from v5 to v5.7.0 (902fa8ec7d6ecbf8d84d538b9b233a880e428804)
- docker/build-push-action from v6 to v6.15.0 (471d1dc4e07e5cdedd4c2171150001c434f0b7a4)
- goreleaser/goreleaser-action from v5 to v6.2.1 (90a3faa9d0182683851fbfa97ca1a2cb983bfca3)
- actions/setup-node from v4 to v4.2.0 (1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a)

### ✅ Checks
- [x] My pull request adheres to the code style of this project
- [x] My code required changes to the documentation; I've included those changes
- [ ] I've added tests to support this change (where applicable)

### Additional Information
This update improves the security posture of the CI/CD pipeline by making GitHub Actions immutable and preventing potential supply chain attacks. The workflow files now reference specific commit hashes along with their corresponding version tags for better traceability and security.